### PR TITLE
Cancel fixes.

### DIFF
--- a/azkaban-executor/azkaban-emr-jobtype/src/main/java/uk/gov/dwp/dataworks/azkaban/jobtype/EMRStep.java
+++ b/azkaban-executor/azkaban-emr-jobtype/src/main/java/uk/gov/dwp/dataworks/azkaban/jobtype/EMRStep.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static azkaban.Constants.ConfigurationKeys.AZKABAN_SERVER_GROUP_NAME;
 import static azkaban.Constants.ConfigurationKeys.AZKABAN_SERVER_NATIVE_LIB_FOLDER;
@@ -493,54 +494,35 @@ public class EMRStep extends AbstractProcessJob {
     return groupName;
   }
 
-  @Override
-  public void cancel() throws InterruptedException {
-    set_job_to_killed();
-
-    String awsRegion = this.getSysProps().getString(AWS_REGION, "eu-west-2");
-
-    AmazonElasticMapReduce emr = AmazonElasticMapReduceClientBuilder.standard()
-            .withRegion(awsRegion)
-            .build();
-
-    String clusterId = null;
-    try {
-      clusterId = getClusterId(emr);
-    } catch (IllegalStateException e) {
-      info("No cluster found, killing job");
-      kill_job();
-      return;
+    @Override
+    public void cancel() {
+        setJobToKilled();
+        if (this.stepIds != null) {
+            List<String> steps = this.stepIds.stream().filter(Objects::nonNull).collect(Collectors.toList());
+            if (steps.size() > 0) {
+                AmazonElasticMapReduce emr = emrClient();
+                EMRUtility.activeClusterId(emr, clusterName()).ifPresent(clusterId -> {
+                    info("Cancelling steps '" + steps + "' on clusterId: '" + clusterId + "'.");
+                    CancelStepsResult result = emr.cancelSteps(getCancelStepsRequest(clusterId, steps));
+                    result.getCancelStepsInfoList().forEach(cancelInfo -> info(
+                            "Cancelled steps '" + steps + "', " + "cancellation status: '" + cancelInfo.getStatus()
+                                    + "', " + "cancellation reason '" + cancelInfo.getReason() + "'."));
+                });
+            }
+        }
     }
 
-    if (clusterId == null) {
-      info("Cluster not returned, killing job");
-      kill_job();
-      return;
-    }
-    info("Retrieved cluster with clusterId: " + clusterId);
-
-    String stepId = this.stepIds.get(0);
-    if (stepId == null) {
-      info("No step found, killing job");
-      kill_job();
-      return;
-    }
-    info("Requesting step to cancel with stepId: " + stepId);
-
-    ArrayList<String> steps = new ArrayList<String>();
-    steps.add(stepId);
-
-    try {
-      emr.cancelSteps(getCancelStepsRequest(clusterId, steps));
-    } catch (IllegalStateException e) {
-      info("Error occurred killing job");
-      kill_job();
-      return;
+    private AmazonElasticMapReduce emrClient() {
+        return AmazonElasticMapReduceClientBuilder.standard().withRegion(awsRegion()).build();
     }
 
-    info("EMR step requested to cancel");
-    kill_job();
-  }
+    private String clusterName() {
+        return this.getJobProps().getString(AWS_EMR_CLUSTER_NAME, this.getSysProps().getString(AWS_EMR_CLUSTER_NAME));
+    }
+
+    private String awsRegion() {
+        return this.getSysProps().getString(AWS_REGION, "eu-west-2");
+    }
 
   private CancelStepsRequest getCancelStepsRequest(String clusterId, Collection<String> stepIds) {
     CancelStepsRequest request = new CancelStepsRequest();
@@ -549,23 +531,10 @@ public class EMRStep extends AbstractProcessJob {
     return request;
   }
 
-  private void set_job_to_killed() throws InterruptedException  {
+  private void setJobToKilled() {
     synchronized (this) {
       this.killed = true;
       this.notify();
-      if (this.process == null) {
-        return;
-      }
-    }
-  }
-
-  private void kill_job() throws InterruptedException  {
-    this.process.awaitStartup();
-    final boolean processkilled = this.process
-            .softKill(KILL_TIME.toMillis(), TimeUnit.MILLISECONDS);
-    if (!processkilled) {
-      warn("Kill with signal TERM failed. Killing with KILL signal.");
-      this.process.hardKill();
     }
   }
 

--- a/azkaban-executor/azkaban-emr-jobtype/src/main/java/uk/gov/dwp/dataworks/azkaban/jobtype/EMRStep.java
+++ b/azkaban-executor/azkaban-emr-jobtype/src/main/java/uk/gov/dwp/dataworks/azkaban/jobtype/EMRStep.java
@@ -174,6 +174,11 @@ public class EMRStep extends AbstractProcessJob {
                                     args.toArray(new String[args.size()])))
             .withActionOnFailure("CONTINUE");
 
+    if (killed) {
+      info("Job has been killed, aborting");
+      return;
+    }
+
     AddJobFlowStepsResult result = emr.addJobFlowSteps(new AddJobFlowStepsRequest()
             .withJobFlowId(clusterId)
             .withSteps(runBashScript));

--- a/azkaban-executor/azkaban-emr-jobtype/src/main/java/uk/gov/dwp/dataworks/azkaban/utility/EMRUtility.java
+++ b/azkaban-executor/azkaban-emr-jobtype/src/main/java/uk/gov/dwp/dataworks/azkaban/utility/EMRUtility.java
@@ -8,15 +8,20 @@ import com.amazonaws.services.elasticmapreduce.model.ListClustersResult;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 public class EMRUtility {
+
+    public static Optional<String> activeClusterId(AmazonElasticMapReduce emr, String clusterName) {
+        return activeClusterSummaries(emr).stream().filter(x -> x.getName().equals(clusterName))
+                .map(ClusterSummary::getId).findFirst();
+    }
 
     public static List<ClusterSummary> activeClusterSummaries(AmazonElasticMapReduce emr) {
         List<ClusterSummary> clusters = new ArrayList<>();
         String marker = "";
         do {
-            ListClustersRequest clustersRequest = clusterRequest(marker);
-            ListClustersResult clustersResult = emr.listClusters(clustersRequest);
+            ListClustersResult clustersResult = emr.listClusters(clusterRequest(marker));
             marker = clustersResult.getMarker();
             clusters.addAll(clustersResult.getClusters());
         } while (marker != null && !marker.trim().equals(""));

--- a/azkaban-executor/azkaban-emr-jobtype/src/test/java/uk/gov/dwp/dataworks/azkaban/utility/EMRUtilityTest.java
+++ b/azkaban-executor/azkaban-emr-jobtype/src/test/java/uk/gov/dwp/dataworks/azkaban/utility/EMRUtilityTest.java
@@ -4,17 +4,16 @@ import com.amazonaws.services.elasticmapreduce.AmazonElasticMapReduce;
 import com.amazonaws.services.elasticmapreduce.model.ClusterSummary;
 import com.amazonaws.services.elasticmapreduce.model.ListClustersRequest;
 import com.amazonaws.services.elasticmapreduce.model.ListClustersResult;
-import groovy.lang.IntRange;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 

--- a/azkaban-executor/azkaban-emr-jobtype/src/test/java/uk/gov/dwp/dataworks/azkaban/utility/EMRUtilityTest.java
+++ b/azkaban-executor/azkaban-emr-jobtype/src/test/java/uk/gov/dwp/dataworks/azkaban/utility/EMRUtilityTest.java
@@ -4,11 +4,13 @@ import com.amazonaws.services.elasticmapreduce.AmazonElasticMapReduce;
 import com.amazonaws.services.elasticmapreduce.model.ClusterSummary;
 import com.amazonaws.services.elasticmapreduce.model.ListClustersRequest;
 import com.amazonaws.services.elasticmapreduce.model.ListClustersResult;
+import groovy.lang.IntRange;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -19,15 +21,19 @@ import static org.mockito.Mockito.*;
 class EMRUtilityTest {
 
     @Test
+    void activeClusterIdReturnsOptionalOfIdWhenFound() {
+        IntStream.range(0, 25).forEach(this::verifyActiveCluster);
+    }
+
+    @Test
+    void activeClusterIdReturnsEmptyOptionalWhenNotFound() {
+        IntStream.range(0, 25).forEach(this::verifyClusterNotFound);
+    }
+
+    @Test
     void activeClusterSummariesReturnsAllPaginatedResults() {
-        ListClustersResult page1 = clustersResult(1, 0, 10);
-        ListClustersResult page2 = clustersResult(2, 10, 20);
-        ListClustersResult page3 = clustersResult(null, 20, 25);
-        AmazonElasticMapReduce emr = mock(AmazonElasticMapReduce.class);
-        when(emr.listClusters(any())).thenReturn(page1, page2, page3);
-
+        AmazonElasticMapReduce emr = emrClient();
         List<ClusterSummary> summaries = EMRUtility.activeClusterSummaries(emr);
-
         ArgumentCaptor<ListClustersRequest> requestCaptor = ArgumentCaptor.forClass(ListClustersRequest.class);
         assertEquals(25, summaries.size());
         IntStream.range(0, 25).forEach(x -> assertEquals(clusterId(x), summaries.get(x).getId()));
@@ -39,12 +45,37 @@ class EMRUtilityTest {
         assertEquals(marker(2), requests.get(2).getMarker());
     }
 
+    private AmazonElasticMapReduce emrClient() {
+        ListClustersResult page1 = clustersResult(1, 0, 10);
+        ListClustersResult page2 = clustersResult(2, 10, 20);
+        ListClustersResult page3 = clustersResult(null, 20, 25);
+        AmazonElasticMapReduce emr = mock(AmazonElasticMapReduce.class);
+        when(emr.listClusters(any())).thenReturn(page1, page2, page3);
+        return emr;
+    }
+
     private ListClustersResult clustersResult(Integer marker, int startId, int endId) {
         ListClustersResult page1 = mock(ListClustersResult.class);
         when(page1.getMarker()).thenReturn(marker(marker));
         List<ClusterSummary> page1Summaries = paginatedSummaries(startId, endId);
         when(page1.getClusters()).thenReturn(page1Summaries);
         return page1;
+    }
+
+    private void verifyActiveCluster(int x) {
+        verifyClusterId("CLUSTER-" + x, "J-" + x, "NOT FOUND " + x);
+    }
+
+    private void verifyClusterNotFound(int x) {
+        verifyClusterId("NON_ACTIVE_CLUSTER-" + x, "NOT FOUND " + x, "NOT FOUND " + x);
+    }
+
+
+    private void verifyClusterId(String clusterName, String expected, String optionalElse) {
+        AmazonElasticMapReduce emr = emrClient();
+        Optional<String> clusterId = EMRUtility.activeClusterId(emr, clusterName);
+        String id = clusterId.orElse(optionalElse);
+        assertEquals(expected, id);
     }
 
     private List<ClusterSummary> paginatedSummaries(int startId, int endId) {
@@ -54,11 +85,16 @@ class EMRUtilityTest {
     private ClusterSummary clusterSummary(int x) {
         ClusterSummary summary = mock(ClusterSummary.class);
         when(summary.getId()).thenReturn(clusterId(x));
+        when(summary.getName()).thenReturn(clusterName(x));
         return summary;
     }
 
-    private String clusterId(int x) {
+    private String clusterName(int x) {
         return "CLUSTER-" + x;
+    }
+
+    private String clusterId(int x) {
+        return "J-" + x;
     }
 
     private String marker(Integer x) {


### PR DESCRIPTION
On cancelling a job do not only get the list of cluster ids on condition
that the job has been killed (because it will have been) and do not kill
the azkaban process because it can only ever be null.
