### PR TITLE
adding ability to pass in s3 location override to EMR launcher, using Azkaban

### DIFF
--- a/azkaban-executor/azkaban-emr-jobtype/build.gradle
+++ b/azkaban-executor/azkaban-emr-jobtype/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     implementation "com.amazonaws:aws-java-sdk-logs:${awsVersion}"
     testImplementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     testImplementation "org.mockito:mockito-core:3.+"
+    testImplementation "net.javacrumbs.json-unit:json-unit-assertj:2.25.0"
+
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter:5.4.2'
 
     extraLibs "com.amazonaws:aws-java-sdk-core:${awsVersion}"

--- a/azkaban-executor/azkaban-emr-jobtype/src/main/java/uk/gov/dwp/dataworks/azkaban/jobtype/EMRStep.java
+++ b/azkaban-executor/azkaban-emr-jobtype/src/main/java/uk/gov/dwp/dataworks/azkaban/jobtype/EMRStep.java
@@ -50,6 +50,7 @@ public class EMRStep extends AbstractProcessJob {
   public static final String COMMAND = "step";
   public static final String AWS_EMR_CLUSTER_NAME = "aws.emr.cluster.name";
   public static final String AWS_EMR_CLUSTER_STATEFILE = "aws.emr.cluster.statefile";
+  public static final String AWS_EMR_CLUSTER_CONFIG = "aws.emr.cluster.config";
   public static final String AWS_EMR_STEP_SCRIPT = "aws.emr.step.script";
   public static final String AWS_EMR_STEP_NAME = "aws.emr.step.name";
   public static final String AZKABAN_MEMORY_CHECK = "azkaban.memory.check";
@@ -308,7 +309,8 @@ public class EMRStep extends AbstractProcessJob {
 
     int pollTime = this.getSysProps().getInt(BOOT_POLL_INTERVAL, BOOT_POLL_INTERVAL_DEFAULT);
     int maxAttempts = this.getSysProps().getInt(BOOT_POLL_ATTEMPTS_MAX, BOOT_POLL_ATTEMPTS_MAX_DEFAULT);
-    String clusterName = this.getJobProps().getString( AWS_EMR_CLUSTER_NAME, this.getSysProps().getString(AWS_EMR_CLUSTER_NAME));
+    String clusterName = this.getJobProps().getString(AWS_EMR_CLUSTER_NAME, this.getSysProps().getString(AWS_EMR_CLUSTER_NAME));
+    String clusterConfig = this.getJobProps().getString(AWS_EMR_CLUSTER_CONFIG);
     info("Looking for cluster named '" + clusterName + "'.");
     while(!killed && clusterId == null && maxAttempts > 0) {
       List<ClusterSummary> clusters = EMRUtility.activeClusterSummaries(emr);
@@ -322,7 +324,7 @@ public class EMRStep extends AbstractProcessJob {
 
       if (clusterId == null && !invokedLambda) {
         info("No active cluster named: '" + clusterName + "', starting one up.");
-        EMRConfiguration batchConfig = EMRConfiguration.builder().withName(clusterName).build();
+        EMRConfiguration batchConfig = EMRConfiguration.builder().withName(clusterName).withS3Overrides(clusterConfig).build();
 
         String payload = "{}";
 

--- a/azkaban-executor/azkaban-emr-jobtype/src/main/java/uk/gov/dwp/dataworks/lambdas/EMRConfiguration.java
+++ b/azkaban-executor/azkaban-emr-jobtype/src/main/java/uk/gov/dwp/dataworks/lambdas/EMRConfiguration.java
@@ -1,9 +1,18 @@
 package uk.gov.dwp.dataworks.lambdas;
 
 import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
 
+@JsonSerialize(include=JsonSerialize.Inclusion.NON_NULL)
 public class EMRConfiguration {
     private Overrides overrides;
+
+    private S3Overrides s3Overrides;
+
+    public EMRConfiguration(String name, String config){
+        this.overrides = new Overrides(name);
+        this.s3Overrides = new S3Overrides(config);
+    }
 
     public EMRConfiguration(String name){
         this.overrides = new Overrides(name);
@@ -12,21 +21,34 @@ public class EMRConfiguration {
     public static EMRConfigurationBuilder builder() {
         return new EMRConfigurationBuilder();
     }
-
     public Overrides getOverrides() {
         return overrides;
     }
 
+    @JsonProperty("s3_overrides")
+    public S3Overrides getS3Overrides() { return s3Overrides; }
+
+
     public static class EMRConfigurationBuilder {
         private String name;
+        private String config;
 
         public EMRConfigurationBuilder withName(String name) {
             this.name = name;
             return this;
         }
 
+        public EMRConfigurationBuilder withS3Overrides(String config) {
+            this.config = config;
+            return this;
+        }
+
         public EMRConfiguration build() {
-            return new EMRConfiguration(this.name);
+            if (this.config != null){
+                return new EMRConfiguration(this.name, this.config);
+            } else {
+                return new EMRConfiguration(this.name);
+            }
         }
     }
 
@@ -41,6 +63,20 @@ public class EMRConfiguration {
         @JsonProperty("Name")
         public String getName() {
             return this.name;
+        }
+    }
+
+    public static class S3Overrides {
+
+        private String config;
+
+        public S3Overrides(String config) {
+            this.config = config;
+        }
+
+        @JsonProperty("emr_launcher_config_s3_folder")
+        public String getConfig() {
+            return this.config;
         }
     }
 }

--- a/azkaban-executor/azkaban-emr-jobtype/src/main/java/uk/gov/dwp/dataworks/lambdas/EMRConfiguration.java
+++ b/azkaban-executor/azkaban-emr-jobtype/src/main/java/uk/gov/dwp/dataworks/lambdas/EMRConfiguration.java
@@ -11,11 +11,9 @@ public class EMRConfiguration {
 
     public EMRConfiguration(String name, String config){
         this.overrides = new Overrides(name);
-        this.s3Overrides = new S3Overrides(config);
-    }
-
-    public EMRConfiguration(String name){
-        this.overrides = new Overrides(name);
+        if (config != null){
+            this.s3Overrides = new S3Overrides(config);
+        }
     }
 
     public static EMRConfigurationBuilder builder() {
@@ -44,11 +42,7 @@ public class EMRConfiguration {
         }
 
         public EMRConfiguration build() {
-            if (this.config != null){
-                return new EMRConfiguration(this.name, this.config);
-            } else {
-                return new EMRConfiguration(this.name);
-            }
+            return new EMRConfiguration(this.name, this.config);
         }
     }
 

--- a/azkaban-executor/azkaban-emr-jobtype/src/test/java/uk/gov/dwp/dataworks/lambdas/EMRConfigurationTest.java
+++ b/azkaban-executor/azkaban-emr-jobtype/src/test/java/uk/gov/dwp/dataworks/lambdas/EMRConfigurationTest.java
@@ -3,7 +3,7 @@ package uk.gov.dwp.dataworks.lambdas;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import com.fasterxml.jackson.databind.JsonNode;
+import net.javacrumbs.jsonunit.assertj.JsonAssertions;
 
 import java.io.IOException;
 
@@ -21,22 +21,17 @@ class EMRConfigurationTest {
         EMRConfiguration test = EMRConfiguration.builder().withName("test_name").build();
         ObjectMapper mapper = new ObjectMapper();
         String event = mapper.writeValueAsString(test);
+
         assertEquals("{'overrides':{'Name':'test_name'}}".replaceAll("'", "\""), event);
     }
 
     @Test
     public void hasCorrectJsonStructureNameAndConfigLocation() throws IOException {
-        EMRConfiguration test = EMRConfiguration.builder().withName("test_name").withS3Overrides("test/config.yml").build();
+        EMRConfiguration test = EMRConfiguration.builder().withName("test_name").withS3Overrides("test/config_path").build();
         ObjectMapper mapper = new ObjectMapper();
         String event = mapper.writeValueAsString(test);
-        try {
 
-            JsonNode jsonNode = mapper.readValue(event, JsonNode.class);
-            assertEquals("{'Name':'test_name'}", jsonNode.get("overrides").asText());
-            assertEquals("{'emr_launcher_config_s3_folder':'test/config.yml'}", jsonNode.get("s3_overrides").asText());
-
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        JsonAssertions.assertThatJson(event)
+                .isEqualTo("{\"overrides\":{\"Name\":\"test_name\"},\"s3_overrides\":{\"emr_launcher_config_s3_folder\":\"test/config_path\"}}");
     }
 }

--- a/azkaban-executor/azkaban-emr-jobtype/src/test/java/uk/gov/dwp/dataworks/lambdas/EMRConfigurationTest.java
+++ b/azkaban-executor/azkaban-emr-jobtype/src/test/java/uk/gov/dwp/dataworks/lambdas/EMRConfigurationTest.java
@@ -3,6 +3,7 @@ package uk.gov.dwp.dataworks.lambdas;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import java.io.IOException;
 
@@ -16,10 +17,26 @@ class EMRConfigurationTest {
     }
 
     @Test
-    public void hasCorrectJsonStructure() throws IOException {
+    public void hasCorrectJsonStructureNameOnly() throws IOException {
         EMRConfiguration test = EMRConfiguration.builder().withName("test_name").build();
         ObjectMapper mapper = new ObjectMapper();
         String event = mapper.writeValueAsString(test);
         assertEquals("{'overrides':{'Name':'test_name'}}".replaceAll("'", "\""), event);
+    }
+
+    @Test
+    public void hasCorrectJsonStructureNameAndConfigLocation() throws IOException {
+        EMRConfiguration test = EMRConfiguration.builder().withName("test_name").withS3Overrides("test/config.yml").build();
+        ObjectMapper mapper = new ObjectMapper();
+        String event = mapper.writeValueAsString(test);
+        try {
+
+            JsonNode jsonNode = mapper.readValue(event, JsonNode.class);
+            assertEquals("{'Name':'test_name'}", jsonNode.get("overrides").asText());
+            assertEquals("{'emr_launcher_config_s3_folder':'test/config.yml'}", jsonNode.get("s3_overrides").asText());
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 }


### PR DESCRIPTION
 - `AWS_EMR_CLUSTER_CONFIG` variable and added to builder in emr step
 - Json serialising class has new nested class for s3 overrides
 - Json serialising class has new constructor to allow additional override
 - Tests for new flow