### PR TITLE
Fix cancellation issue.

### DIFF
--- a/azkaban-executor/azkaban-emr-jobtype/src/main/java/uk/gov/dwp/dataworks/azkaban/jobtype/EmrLauncherJob.java
+++ b/azkaban-executor/azkaban-emr-jobtype/src/main/java/uk/gov/dwp/dataworks/azkaban/jobtype/EmrLauncherJob.java
@@ -18,9 +18,7 @@ import uk.gov.dwp.dataworks.azkaban.services.StatusService;
 import uk.gov.dwp.dataworks.azkaban.utility.ClientUtility;
 import uk.gov.dwp.dataworks.azkaban.utility.PropertyUtility;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class EmrLauncherJob extends AbstractProcessJob {
 
@@ -40,14 +38,12 @@ public class EmrLauncherJob extends AbstractProcessJob {
     }
 
     @Override
-    public void run() throws Exception {
+    public void run() {
         List<String> collections = propertyUtility.collectionDependencies();
-        boolean successful = collections.size() > 0 ?
-                service().launchClusterAndWaitForStepCompletion(dependency(), collections.toArray(new String[0])) :
-                service().launchClusterAndWaitForStepCompletion(dependency());
-
-        if (!successful) {
-            throw new Exception("Job failed");
+        if (collections.size() > 0) {
+            service().launchClusterAndWaitForStepCompletion(dependency(), collections.toArray(new String[0]));
+        } else {
+            service().launchClusterAndWaitForStepCompletion(dependency());
         }
     }
 

--- a/azkaban-executor/azkaban-emr-jobtype/src/test/java/uk/gov/dwp/dataworks/azkaban/services/DependencyServiceTest.java
+++ b/azkaban-executor/azkaban-emr-jobtype/src/test/java/uk/gov/dwp/dataworks/azkaban/services/DependencyServiceTest.java
@@ -218,6 +218,17 @@ class DependencyServiceTest {
         verify(dynamoDB, times(6)).scan(any());
     }
 
+    @Test
+    public void shouldCancelDelegates() {
+        AmazonDynamoDB dynamoDB = mock(AmazonDynamoDB.class);
+        DataProductStatusService dataProductStatusService = mock(DataProductStatusService.class);
+        CollectionStatusService collectionStatusService = mock(CollectionStatusService.class);
+        DependencyService dependencyService = new DependencyService(dynamoDB, dataProductStatusService, collectionStatusService, EXPORT_DATE);
+        dependencyService.cancel();
+        verify(dataProductStatusService, times(1)).cancel();
+        verify(collectionStatusService, times(1)).cancel();
+    }
+
     private Map<String, AttributeValue> itemKey() {
         Map<String, AttributeValue> successfulKey = new HashMap<>();
         successfulKey.put(CORRELATION_ID_FIELD, new AttributeValue().withS(CORRELATION_ID_1));


### PR DESCRIPTION
Cancellation during collection status check was effectively ignored
prior to this change. The CollectionStatusService 'cancel' method
was never called before now.
