### PR TITLE
Add executor check as cron job

### DIFF
--- a/azkaban-webserver/Dockerfile
+++ b/azkaban-webserver/Dockerfile
@@ -21,6 +21,7 @@ FROM openjdk:8-alpine
 
 COPY --from=gradle-builder /tmp/azkaban-web-server.tar.gz /tmp/azkaban-web-server.tar.gz
 COPY --from=gradle-builder /tmp/azkaban-db.tar.gz /tmp/azkaban-db.tar.gz
+COPY executor_check.sh /bin/executor_check.sh
 COPY entrypoint.sh /bin/entrypoint.sh
 
 RUN sed -i -e 's/v[[:digit:]]\..*\//edge\//g' /etc/apk/repositories && \

--- a/azkaban-webserver/entrypoint.sh
+++ b/azkaban-webserver/entrypoint.sh
@@ -3,30 +3,30 @@ set -e
 
 echo "INFO: Checking container configuration..."
 if [ -z "${AZKABAN_CONFIG_S3_BUCKET}" -o -z "${AZKABAN_CONFIG_S3_PREFIX}" ]; then
-  echo "ERROR: AZKABAN_CONFIG_S3_BUCKET and AZKABAN_CONFIG_S3_PREFIX environment variables must be provided"
-  exit 1
+    echo "ERROR: AZKABAN_CONFIG_S3_BUCKET and AZKABAN_CONFIG_S3_PREFIX environment variables must be provided"
+    exit 1
 fi
 
 S3_URI="s3://${AZKABAN_CONFIG_S3_BUCKET}/${AZKABAN_CONFIG_S3_PREFIX}"
 
 # If either of the AWS credentials variables were provided, validate them
 if [ -n "${AWS_ACCESS_KEY_ID}${AWS_SECRET_ACCESS_KEY}" ]; then
-  if [ -z "${AWS_ACCESS_KEY_ID}" -o -z "${AWS_SECRET_ACCESS_KEY}" ]; then
-    echo "ERROR: You must provide both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY variables if you want to use access key based authentication"
-    exit 1
-  else
-    echo "INFO: Using supplied access key for authentication"
-  fi
-
-  # If either of the ASSUMEROLE variables were provided, validate them and configure a shared credentials fie
-  if [ -n "${AWS_ASSUMEROLE_ACCOUNT}${AWS_ASSUMEROLE_ROLE}" ]; then
-    if [ -z "${AWS_ASSUMEROLE_ACCOUNT}" -o -z "${AWS_ASSUMEROLE_ROLE}" ]; then
-      echo "ERROR: You must provide both the AWS_ASSUMEROLE_ACCOUNT and AWS_ASSUMEROLE_ROLE variables if you want to assume role"
-      exit 1
+    if [ -z "${AWS_ACCESS_KEY_ID}" -o -z "${AWS_SECRET_ACCESS_KEY}" ]; then
+        echo "ERROR: You must provide both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY variables if you want to use access key based authentication"
+        exit 1
     else
-      ASSUME_ROLE="arn:aws:iam::${AWS_ASSUMEROLE_ACCOUNT}:role/${AWS_ASSUMEROLE_ROLE}"
-      echo "INFO: Configuring AWS credentials for assuming role to ${ASSUME_ROLE}..."
-      mkdir ~/.aws
+        echo "INFO: Using supplied access key for authentication"
+    fi
+    
+    # If either of the ASSUMEROLE variables were provided, validate them and configure a shared credentials fie
+    if [ -n "${AWS_ASSUMEROLE_ACCOUNT}${AWS_ASSUMEROLE_ROLE}" ]; then
+        if [ -z "${AWS_ASSUMEROLE_ACCOUNT}" -o -z "${AWS_ASSUMEROLE_ROLE}" ]; then
+            echo "ERROR: You must provide both the AWS_ASSUMEROLE_ACCOUNT and AWS_ASSUMEROLE_ROLE variables if you want to assume role"
+            exit 1
+        else
+            ASSUME_ROLE="arn:aws:iam::${AWS_ASSUMEROLE_ACCOUNT}:role/${AWS_ASSUMEROLE_ROLE}"
+            echo "INFO: Configuring AWS credentials for assuming role to ${ASSUME_ROLE}..."
+            mkdir ~/.aws
       cat > ~/.aws/credentials << EOF
 [default]
 aws_access_key_id=${AWS_ACCESS_KEY_ID}
@@ -35,19 +35,19 @@ aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}
 role_arn=${ASSUME_ROLE}
 source_profile=default
 EOF
-      PROFILE_OPTION="--profile ${AWS_ASSUMEROLE_ROLE}"
+            PROFILE_OPTION="--profile ${AWS_ASSUMEROLE_ROLE}"
+        fi
     fi
-  fi
-  if [ -n "${AWS_SESSION_TOKEN}" ]; then
-    sed -i -e "/aws_secret_access_key/a aws_session_token=${AWS_SESSION_TOKEN}" ~/.aws/credentials
-  fi
+    if [ -n "${AWS_SESSION_TOKEN}" ]; then
+        sed -i -e "/aws_secret_access_key/a aws_session_token=${AWS_SESSION_TOKEN}" ~/.aws/credentials
+    fi
 else
-  echo "INFO: Using attached IAM roles/instance profiles to authenticate with S3 as no AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY have been provided"
+    echo "INFO: Using attached IAM roles/instance profiles to authenticate with S3 as no AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY have been provided"
 fi
 
 if [ -n "$KEYSTORE_DATA" ]; then
-  echo $KEYSTORE_DATA | base64 -d > /store.jwk
-  export KEYSTORE_URL='file:////store.jwk'
+    echo $KEYSTORE_DATA | base64 -d > /store.jwk
+    export KEYSTORE_URL='file:////store.jwk'
 fi
 
 echo "INFO: Copying azkaban web-server configuration file(s) from ${S3_URI} to /azkaban-web-server/conf..."
@@ -61,8 +61,8 @@ AZKABAN_SECRET_ID="$(grep "aws.azkaban.secretid" /azkaban-web-server/conf/azkaba
 RDS_SECRET_ID="$(grep "aws.rds.secretid" /azkaban-web-server/conf/azkaban.properties | sed 's|.*=||g')"
 
 if [ -z "${AZKABAN_SECRET_ID}" -o -z "${RDS_SECRET_ID}" ]; then
-  echo "ERROR: The AZKABAN_SECRET_ID and RDS_SECRET_ID variables not set. Could not find in the azkaban.properties file"
-  exit 1
+    echo "ERROR: The AZKABAN_SECRET_ID and RDS_SECRET_ID variables not set. Could not find in the azkaban.properties file"
+    exit 1
 fi
 
 SECRETS=$(aws secretsmanager get-secret-value --secret-id $AZKABAN_SECRET_ID --query SecretBinary --output text | base64 -d )
@@ -89,25 +89,30 @@ cat <<EOF > /azkaban-web-server/conf/azkaban-users.xml
 EOF
 
 while IFS='=' read -r prop val; do
-  case $prop in
-    jetty.password | jetty.keypassword | jetty.trustpassword)
-      val=$(echo $SECRETS | jq -r .keystore_password)
-      ;;
-    jetty.port)
-      val=$(echo $SECRETS | jq -r .ports.azkaban_webserver_port)
-      ;;
-    mysql.database)
-      val=$DB_NAME
-      ;;
-    mysql.user)
-      val=$DB_USERNAME
-      ;;
-    mysql.password)
-      val=$DB_PASSWORD
-      ;;
-  esac
-  printf '%s\n' "$prop=$val"
+    case $prop in
+        jetty.password | jetty.keypassword | jetty.trustpassword)
+            val=$(echo $SECRETS | jq -r .keystore_password)
+        ;;
+        jetty.port)
+            val=$(echo $SECRETS | jq -r .ports.azkaban_webserver_port)
+        ;;
+        mysql.database)
+            val=$DB_NAME
+        ;;
+        mysql.user)
+            val=$DB_USERNAME
+        ;;
+        mysql.password)
+            val=$DB_PASSWORD
+        ;;
+    esac
+    printf '%s\n' "$prop=$val"
 done < /azkaban-web-server/conf/azkaban.properties > file.tmp && mv file.tmp /azkaban-web-server/conf/azkaban.properties
 
+echo "* /5 * * * /executor_check.sh >> /var/log/cron.log 2>&1
+# This extra line makes it a valid cron" > scheduler.txt"
+
 echo "INFO: Starting azkaban web-server..."
-exec /azkaban-web-server/bin/start-web.sh
+exec /azkaban-web-server/bin/start-web.sh  && \
+      crontab scheduler.txt && \
+      cron -f

--- a/azkaban-webserver/executor_check.sh
+++ b/azkaban-webserver/executor_check.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+mysql $DB_NAME -e < SELECT DISTINCT host FROM $DB_NAME.executors; > executors.list
+
+for executor_host in $(cat executors.list);
+do
+    if [[ $(nc -v -z -w5 $executor_host 7082 && echo $?) != 0 ]]; then
+        echo "$executor_host appears to be down, removing from active list..."
+        mysql $DB_NAME < DELETE FROM $DB_NAME.executors WHERE host LIKE \'${executor_host}\'; >
+    else
+        echo "$executor_host available"
+    fi
+done

--- a/azkaban-webserver/executor_check.sh
+++ b/azkaban-webserver/executor_check.sh
@@ -7,7 +7,7 @@ for executor_host in $(cat executors.list);
 do
     if [[ $(nc -v -z -w5 $executor_host 7082 && echo $?) != 0 ]]; then
         echo "$executor_host appears to be down, removing from active list..."
-        mysql $DB_NAME < DELETE FROM $DB_NAME.executors WHERE host LIKE \'${executor_host}\'; >
+        mysql $DB_NAME -e DELETE FROM $DB_NAME.executors WHERE host LIKE \'${executor_host}\';
     else
         echo "$executor_host available"
     fi


### PR DESCRIPTION
This adds a new script which is ran every 5 minutes using `cron`.  
The script is designed to query the Azkaban DB `executors` table and iterate over each entries availability.  If any fail to respond, their entry is removed from the table.