### PR TITLE
Add crond to start-web

### DIFF
--- a/azkaban-webserver/Dockerfile
+++ b/azkaban-webserver/Dockerfile
@@ -21,8 +21,11 @@ FROM openjdk:8-alpine
 
 COPY --from=gradle-builder /tmp/azkaban-web-server.tar.gz /tmp/azkaban-web-server.tar.gz
 COPY --from=gradle-builder /tmp/azkaban-db.tar.gz /tmp/azkaban-db.tar.gz
-COPY executor_check.sh /bin/executor_check
 COPY entrypoint.sh /bin/entrypoint.sh
+
+COPY executor_check.sh /bin/executor_check
+RUN chmod 755 /bin/executor_check
+RUN echo '*/5 * * * * /bin/executor_check' > /var/spool/cron/crontabs/root
 
 RUN sed -i -e 's/v[[:digit:]]\..*\//edge\//g' /etc/apk/repositories && \
     apk upgrade --update-cache --available && \
@@ -43,11 +46,6 @@ RUN sed -i -e 's/v[[:digit:]]\..*\//edge\//g' /etc/apk/repositories && \
     mv /tmp/azkaban-db-0.1.0-SNAPSHOT /azkaban-db && \
     chown -R nobody:nogroup /azkaban-web-server && \
     chmod 755 /bin/entrypoint.sh
-
-RUN chmod 755 /bin/executor_check
-
-RUN echo '*/5 * * * * /bin/executor_check' > /etc/crontabs/root
-CMD ["crond", "-l 2", "-f"]
 
 COPY dist/jackson-annotations-2.11.1.jar /azkaban-web-server/lib/jackson-annotations-2.11.1.jar
 COPY dist/jackson-core-2.11.1.jar /azkaban-web-server/lib/jackson-core-2.11.1.jar

--- a/azkaban-webserver/entrypoint.sh
+++ b/azkaban-webserver/entrypoint.sh
@@ -17,7 +17,7 @@ if [ -n "${AWS_ACCESS_KEY_ID}${AWS_SECRET_ACCESS_KEY}" ]; then
     else
         echo "INFO: Using supplied access key for authentication"
     fi
-
+    
     # If either of the ASSUMEROLE variables were provided, validate them and configure a shared credentials fie
     if [ -n "${AWS_ASSUMEROLE_ACCOUNT}${AWS_ASSUMEROLE_ROLE}" ]; then
         if [ -z "${AWS_ASSUMEROLE_ACCOUNT}" -o -z "${AWS_ASSUMEROLE_ROLE}" ]; then
@@ -108,6 +108,9 @@ while IFS='=' read -r prop val; do
     esac
     printf '%s\n' "$prop=$val"
 done < /azkaban-web-server/conf/azkaban.properties > file.tmp && mv file.tmp /azkaban-web-server/conf/azkaban.properties
+
+echo "INFO: Adding crond to launch"
+sed -i 's/${script_dir}/crond \-S \&\& \${script_dir}/' /azkaban-web-server/bin/start-web.sh
 
 echo "INFO: crontab list"
 crontab -l


### PR DESCRIPTION
Adds cron job to default crontab file
Add `crond` to run with `start-web` script, in the background, and use syslog.