### PR TITLE
Kill container if executor hosts cleared from database

### DIFF
--- a/azkaban-webserver/executor_check.sh
+++ b/azkaban-webserver/executor_check.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-echo "Obtaining executor list...\n"
+echo "Obtaining executor list..."
 mysql -h $DB_HOST -u $DB_USERNAME -p$DB_PASSWORD $DB_NAME -e "SELECT DISTINCT host FROM $DB_NAME.executors;" > /executors.list
 
 echo "Current Executors:"
@@ -10,10 +10,18 @@ cat /executors.list
 # Executors list contains 'host' mysql header - ignore first line
 for executor_host in $(tail -n +2 /executors.list);
 do
+  killed_instances=0
     if [[ $(nc -v -z -w5 $executor_host 7082 && echo $?) != 0 ]]; then
         echo "$executor_host appears to be down, removing from active list..."
         mysql -h $DB_HOST -u $DB_USERNAME -p$DB_PASSWORD $DB_NAME -e "DELETE FROM $DB_NAME.executors WHERE host LIKE '${executor_host}';"
+        (( killed_instances++ ))
     else
         echo "$executor_host available"
     fi
+
+#    Kill the container after clearing all dead hosts - required because Azkaban doesn't read database after starting
+  if [[ "${killed_instances}" != 0 ]]; then
+    echo "Killing container after clearing dead executor hosts from database"
+    pkill -9 java
+  fi
 done


### PR DESCRIPTION
The version of Azkaban in use needs to be restarted in order to acquire updated executor list. If executor hosts have been cleared from the database, we must restart the web server. Killing the container will bring up another one.

Signed-off-by: Connor Avery <ConnorAvery@digital.uc.dwp.gov.uk>