### PR TITLE
Move azkaban-webserver to java 12.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 local/
 .dcignore
 .jqwik-database
+rad/

--- a/azkaban-webserver/Dockerfile
+++ b/azkaban-webserver/Dockerfile
@@ -7,17 +7,17 @@ USER root
 COPY azkaban-cognito-usermanager /tmp/azkaban-cognito-usermanager
 COPY dist/LoginAbstractAzkabanServlet.java /tmp/LoginAbstractAzkabanServlet.java
 
-RUN curl -k -LSs --output /tmp/azkaban.tar.gz https://github.com/azkaban/azkaban/archive/$AZK_VERSION.tar.gz && \
-    tar -C /tmp -zoxf /tmp/azkaban.tar.gz && \
-    mv -f /tmp/LoginAbstractAzkabanServlet.java /tmp/azkaban-$AZK_VERSION/azkaban-web-server/src/main/java/azkaban/webapp/servlet && \
-    cat /tmp/azkaban-$AZK_VERSION/build.gradle | sed -e 's/httpclient:4.5.3/httpclient:4.5.13/' > /tmp/build.gradle && \
-    mv /tmp/build.gradle /tmp/azkaban-$AZK_VERSION/build.gradle && \
-    /tmp/azkaban-$AZK_VERSION/gradlew -p /tmp/azkaban-$AZK_VERSION assemble && \
-    /tmp/azkaban-cognito-usermanager/gradlew -p /tmp/azkaban-cognito-usermanager assemble && \
-    mv /tmp/azkaban-$AZK_VERSION/azkaban-web-server/build/distributions/azkaban-web-server-0.1.0-SNAPSHOT.tar.gz /tmp/azkaban-web-server.tar.gz && \
-    mv /tmp/azkaban-$AZK_VERSION/azkaban-db/build/distributions/azkaban-db-0.1.0-SNAPSHOT.tar.gz /tmp/azkaban-db.tar.gz
+RUN curl -k -LSs --output /tmp/azkaban.tar.gz https://github.com/azkaban/azkaban/archive/$AZK_VERSION.tar.gz
+RUN tar -C /tmp -zoxf /tmp/azkaban.tar.gz
+RUN mv -f /tmp/LoginAbstractAzkabanServlet.java /tmp/azkaban-$AZK_VERSION/azkaban-web-server/src/main/java/azkaban/webapp/servlet
+RUN cat /tmp/azkaban-$AZK_VERSION/build.gradle | sed -e 's/httpclient:4.5.3/httpclient:4.5.13/' > /tmp/build.gradle
+RUN mv /tmp/build.gradle /tmp/azkaban-$AZK_VERSION/build.gradle
+RUN /tmp/azkaban-$AZK_VERSION/gradlew -p /tmp/azkaban-$AZK_VERSION assemble
+RUN /tmp/azkaban-cognito-usermanager/gradlew -p /tmp/azkaban-cognito-usermanager assemble
+RUN mv /tmp/azkaban-$AZK_VERSION/azkaban-web-server/build/distributions/azkaban-web-server-0.1.0-SNAPSHOT.tar.gz /tmp/azkaban-web-server.tar.gz
+RUN mv /tmp/azkaban-$AZK_VERSION/azkaban-db/build/distributions/azkaban-db-0.1.0-SNAPSHOT.tar.gz /tmp/azkaban-db.tar.gz
 
-FROM openjdk:8-alpine
+FROM openjdk:12-alpine
 
 COPY --from=gradle-builder /tmp/azkaban-web-server.tar.gz /tmp/azkaban-web-server.tar.gz
 COPY --from=gradle-builder /tmp/azkaban-db.tar.gz /tmp/azkaban-db.tar.gz

--- a/azkaban-webserver/Makefile
+++ b/azkaban-webserver/Makefile
@@ -1,12 +1,14 @@
 SHELL:=bash
 
-aws_mgmt_dev_account=""
-aws_default_region=""
-temp_image_tag=""
+aws_mgmt_dev_account=POPULATE_ME
+aws_default_region=POPULATE_ME
 
-push-webserver-to-ecr: ## Push a temp version of the consumer to AWS MGMT-DEV ECR
+build:
+	docker build -t azkaban-webserver .
+
+publish:
 	@{ \
 		aws ecr get-login-password --region $(aws_default_region) --profile dataworks-management-dev | docker login --username AWS --password-stdin $(aws_mgmt_dev_account).dkr.ecr.$(aws_default_region).amazonaws.com; \
-		docker tag azkaban-webserver $(aws_mgmt_dev_account).dkr.ecr.$(aws_default_region).amazonaws.com/azkaban-webserver:$(temp_image_tag); \
-		docker push $(aws_mgmt_dev_account).dkr.ecr.$(aws_default_region).amazonaws.com/azkaban-webserver:$(temp_image_tag); \
+		docker tag azkaban-webserver $(aws_mgmt_dev_account).dkr.ecr.$(aws_default_region).amazonaws.com/azkaban-webserver:development; \
+		docker push $(aws_mgmt_dev_account).dkr.ecr.$(aws_default_region).amazonaws.com/azkaban-webserver:development; \
 	}

--- a/azkaban-webserver/cycle_containers.sh
+++ b/azkaban-webserver/cycle_containers.sh
@@ -1,16 +1,39 @@
 #! /bin/sh
 
+set -x
 
 prog=$(basename $0)
 
 
 main() {
+    OPTIND=1
+
+    local options=":s:"
+
+    while getopts $options opt; do
+        case $opt in
+            s)
+                local -r service_override=$OPTARG
+                ;;
+            \?)
+                stderr Usage: $FUNCNAME [ $options ]
+                return 2
+                ;;
+        esac
+    done
+
+    shift $((OPTIND - 1))
+
+
+
     local -r profile=${1:?Usage: $prog $(args)}
     local -r cluster=${2:?Usage: $prog $(args)}
     local -r task_definition=${3:?Usage: $prog $(args)}
 
-    if stop_service $profile $cluster; then
-        start_service $profile $cluster $task_definition
+    local -r service=${service_override:-azkaban-external-webserver}
+
+    if stop_service $profile $cluster $service; then
+        start_service $profile $cluster $service $task_definition
     else
         echo Failed to shut down web server
         return 1
@@ -18,16 +41,20 @@ main() {
 }
 
 stop_service() {
-    local -r profile=${1:?Usage $FUNCNAME profile cluster}
-    local -r cluster=${2:?Usage $FUNCNAME profile cluster}
+    local -r profile=${1:?Usage $FUNCNAME profile cluster service}
+    local -r cluster=${2:?Usage $FUNCNAME profile cluster service}
+    local -r service=${3:?Usage $FUNCNAME profile cluster service}
 
-    aws --profile $profile --no-paginate ecs update-service --cluster $cluster \
-        --service azkaban-webserver \
+    aws --profile $profile \
+        --no-paginate \
+        ecs update-service \
+        --cluster $cluster \
+        --service $service \
         --force-new-deployment \
         --desired-count 0  > /dev/null
 
     timeout 10m bash <<EOF
-    while [[ \$(running_count $profile $cluster) -gt 0 ]]; do
+    while [[ \$(running_count $profile $cluster $service) -gt 0 ]]; do
         echo Waiting for container count to reach 0.
         sleep 10
     done
@@ -36,18 +63,20 @@ EOF
 }
 
 start_service() {
-    local -r profile=${1:?Usage: $prog $(args)}
-    local -r cluster=${2:?Usage: $prog $(args)}
-    local -r task_definition=${3:?Usage: $prog $(args)}
+    local -r profile=${1:?Usage: $FUNCNAME profile cluster service task-definition}
+    local -r cluster=${2:?Usage: $FUNCNAME profile cluster service task-definition}
+    local -r service=${3:?Usage $FUNCNAME profile cluster service task-definition}
+    local -r task_definition=${4:?Usage: $FUNCNAME profile cluster service task-definition}
 
     aws --profile $profile --no-paginate \
         ecs update-service \
         --cluster $cluster \
-        --service azkaban-webserver --task-definition $task_definition \
+        --service $service \
+        --task-definition $task_definition \
         --desired-count 1 > /dev/null
 
     timeout 10m bash <<EOF
-    while [[ \$(running_count $profile $cluster) -eq 0 ]]; do
+    while [[ \$(running_count $profile $cluster $service) -eq 0 ]]; do
         echo Waiting for container count to exceed 0.
         sleep 10
     done
@@ -55,16 +84,18 @@ EOF
 }
 
 running_count() {
-    local -r profile=${1:?Usage $FUNCNAME profile cluster}
-    local -r cluster=${2:?Usage $FUNCNAME profile cluster}
+    local -r profile=${1:?Usage $FUNCNAME profile cluster service}
+    local -r cluster=${2:?Usage $FUNCNAME profile cluster service}
+    local -r service=${3:?Usage $FUNCNAME profile cluster service}
+
     aws --profile $profile ecs describe-services --cluster $cluster \
-        --services azkaban-webserver | jq -r '.services[0].runningCount'
+        --services $service | jq -r '.services[0].runningCount'
 }
 
 export -f running_count
 
 args() {
-    echo profile cluster task-definition
+    echo [ -s service ] profile cluster task-definition
 }
 
 

--- a/azkaban-webserver/entrypoint.sh
+++ b/azkaban-webserver/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 set -e
 
 echo "INFO: Checking container configuration..."
@@ -17,7 +18,7 @@ if [ -n "${AWS_ACCESS_KEY_ID}${AWS_SECRET_ACCESS_KEY}" ]; then
     else
         echo "INFO: Using supplied access key for authentication"
     fi
-    
+
     # If either of the ASSUMEROLE variables were provided, validate them and configure a shared credentials fie
     if [ -n "${AWS_ASSUMEROLE_ACCOUNT}${AWS_ASSUMEROLE_ROLE}" ]; then
         if [ -z "${AWS_ASSUMEROLE_ACCOUNT}" -o -z "${AWS_ASSUMEROLE_ROLE}" ]; then
@@ -76,10 +77,10 @@ export DB_USERNAME=$(echo $DB_SECRETS | jq -r .username)
 export DB_PASSWORD=$(echo $DB_SECRETS | jq -r .password)
 export EXECUTOR_PORT=$(aws secretsmanager get-secret-value --secret-id $AZKABAN_SECRET_ID --query SecretBinary --output text | base64 -d | jq '.ports.azkaban_executor_port')
 
-/usr/bin/openssl req -x509 -newkey rsa:4096 -keyout $JAVA_HOME/jre/lib/security/key.pem -out $JAVA_HOME/jre/lib/security/cert.pem -days 30 -nodes -subj "/CN=azkaban"
-keytool -keystore /azkaban-web-server/cacerts -storepass ${PASS} -noprompt -trustcacerts -importcert -alias self_signed -file $JAVA_HOME/jre/lib/security/cert.pem
-openssl req -new -key $JAVA_HOME/jre/lib/security/key.pem -subj "/CN=azkaban" -out $JAVA_HOME/jre/lib/security/cert.csr
-openssl pkcs12 -inkey $JAVA_HOME/jre/lib/security/key.pem -in $JAVA_HOME/jre/lib/security/cert.pem -export -out /azkaban-web-server/cacerts.pkcs12 -passout pass:${PASS}
+/usr/bin/openssl req -x509 -newkey rsa:4096 -keyout $JAVA_HOME/lib/security/key.pem -out $JAVA_HOME/lib/security/cert.pem -days 30 -nodes -subj "/CN=azkaban"
+keytool -keystore /azkaban-web-server/cacerts -storepass ${PASS} -noprompt -trustcacerts -importcert -alias self_signed -file $JAVA_HOME/lib/security/cert.pem
+openssl req -new -key $JAVA_HOME/lib/security/key.pem -subj "/CN=azkaban" -out $JAVA_HOME/lib/security/cert.csr
+openssl pkcs12 -inkey $JAVA_HOME/lib/security/key.pem -in $JAVA_HOME/lib/security/cert.pem -export -out /azkaban-web-server/cacerts.pkcs12 -passout pass:${PASS}
 keytool -importkeystore -srckeystore /azkaban-web-server/cacerts.pkcs12 -storepass ${PASS} -srcstorepass ${PASS} -srcstoretype PKCS12 -destkeystore /azkaban-web-server/cacerts
 
 cat <<EOF > /azkaban-web-server/conf/azkaban-users.xml


### PR DESCRIPTION
Existing java version (8) 'keytool' utility not compatible with
version of openssl now in the alpine repository (released
2021-09-07).
