### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           paths: ${{ matrix.image }}/**
       - name: Publish to DockerHub
-        uses: elgohr/Publish-Docker-Github-Action@191af57e15535d28b83589e3b5f0c31e76aa8733 #v3.0.4 hardcoded for security DW-5986, review regularly
+        uses: elgohr/Publish-Docker-Github-Action@v5 #v3.0.4 hardcoded for security DW-5986, review regularly
         if: steps.has-changed.outputs.changed == 'true'
         with:
           name: dwpdigital/${{ matrix.image }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore